### PR TITLE
Good return values for min_time and max_time

### DIFF
--- a/source/benchmark/phase_metrics.cpp
+++ b/source/benchmark/phase_metrics.cpp
@@ -63,12 +63,12 @@ int64_t PhaseMetrics::avg_time() const noexcept
 
 int64_t PhaseMetrics::min_time() const noexcept
 {
-    return (_total_operations > 0) ? (_min_time / _total_operations) : _min_time;
+    return _min_time;
 }
 
 int64_t PhaseMetrics::max_time() const noexcept
 {
-    return (_total_operations > 0) ? (_max_time / _total_operations) : _max_time;
+    return _max_time;
 }
 
 int64_t PhaseMetrics::operations_per_second() const noexcept

--- a/source/benchmark/reporter_console.cpp
+++ b/source/benchmark/reporter_console.cpp
@@ -26,7 +26,7 @@ void ReporterConsole::ReportHeader()
 void ReporterConsole::ReportSystem()
 {
     _stream << Color::DARKGREY << GenerateSeparator('=') << std::endl;
-    _stream << Color::WHITE << "CPU architecutre: " << Color::LIGHTCYAN << System::CpuArchitecture() << std::endl;
+    _stream << Color::WHITE << "CPU architecture: " << Color::LIGHTCYAN << System::CpuArchitecture() << std::endl;
     _stream << Color::WHITE << "CPU logical cores: " << Color::LIGHTGREEN << System::CpuLogicalCores() << std::endl;
     _stream << Color::WHITE << "CPU physical cores: " << Color::LIGHTGREEN << System::CpuPhysicalCores() << std::endl;
     _stream << Color::WHITE << "CPU clock speed: " << Color::LIGHTGREEN << GenerateClockSpeed(System::CpuClockSpeed()) << std::endl;
@@ -41,7 +41,7 @@ void ReporterConsole::ReportEnvironment()
     _stream << Color::WHITE << "OS version: " << Color::DARKGREY << Environment::OSVersion() << std::endl;
     _stream << Color::WHITE << "OS bits: " << Color::DARKGREY << (Environment::Is64BitOS() ? "64-bit" : (Environment::Is32BitOS() ? "32-bit" : "<unknown>")) << std::endl;
     _stream << Color::WHITE << "Process bits: " << Color::DARKGREY << (Environment::Is64BitProcess() ? "64-bit" : (Environment::Is32BitProcess() ? "32-bit" : "<unknown>")) << std::endl;
-    _stream << Color::WHITE << "Process configuaraion: " << Color::DARKGREY << (Environment::IsDebug() ? "debug" : (Environment::IsRelease() ? "release" : "<unknown>")) << std::endl;
+    _stream << Color::WHITE << "Process configuration: " << Color::DARKGREY << (Environment::IsDebug() ? "debug" : (Environment::IsRelease() ? "release" : "<unknown>")) << std::endl;
     time_t timestamp = Environment::Timestamp();
     _stream << Color::WHITE << "Local timestamp: " << Color::DARKGREY << std::asctime(std::localtime(&timestamp));
     _stream << Color::WHITE << "UTC timestamp: " << Color::DARKGREY << std::asctime(std::gmtime(&timestamp));


### PR DESCRIPTION
When executing the code in Dynamic benchmarks mode (see Example 14), I had weird results for min_time and max_time.
It was because they were divided by _total_operations, like done for avg_time, but shouldn't.
I didn't try the other modes.
Correct me if I'm wrong.