### PR TITLE
Update Catch2 branch name from "master" to "v2.x"

### DIFF
--- a/.gitlinks
+++ b/.gitlinks
@@ -1,5 +1,5 @@
 # Modules
-Catch2 modules/Catch2 https://github.com/catchorg/Catch2.git master
+Catch2 modules/Catch2 https://github.com/catchorg/Catch2.git v2.x
 cpp-optparse modules/cpp-optparse https://github.com/weisslj/cpp-optparse.git master
 HdrHistogram modules/HdrHistogram https://github.com/HdrHistogram/HdrHistogram_c.git master
 zlib modules/zlib https://github.com/madler/zlib.git master


### PR DESCRIPTION
"master" is no longer a valid branch