### PR TITLE
Update HdrHistogram branch

### DIFF
--- a/.gitlinks
+++ b/.gitlinks
@@ -1,7 +1,7 @@
 # Modules
 Catch2 modules/Catch2 https://github.com/catchorg/Catch2.git v2.x
 cpp-optparse modules/cpp-optparse https://github.com/weisslj/cpp-optparse.git master
-HdrHistogram modules/HdrHistogram https://github.com/HdrHistogram/HdrHistogram_c.git master
+HdrHistogram modules/HdrHistogram https://github.com/HdrHistogram/HdrHistogram_c.git main
 zlib modules/zlib https://github.com/madler/zlib.git master
 
 # Scripts


### PR DESCRIPTION
This repo renamed its `master` branch to `main`.

See [HdrHistogram/HdrHistogram_c](https://github.com/HdrHistogram/HdrHistogram_c).