### PR TITLE
Suppress compiler warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ include(SetCompilerWarnings)
 include(SetPlatformFeatures)
 include(SystemInformation)
 
+# Compiler options
+add_compile_options(-w)
+
 # External packages
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
In trying to build this on Arch Linux, I had to add this option to suppress compiler warnings as they were being treated as errors. However, this is at most a temporary fix and a move towards Modern CMake design patterns should be considered to streamline the build process and better implement the library. If you would like help with this, feel free to reach out or use some of my projects (name Graph & FibonacciHeap, or libeztp for an old but robust example) as references.