### PR TITLE
fix average time error

### DIFF
--- a/source/benchmark/benchmark.cpp
+++ b/source/benchmark/benchmark.cpp
@@ -61,9 +61,6 @@ void Benchmark::Launch(int& current, int total, LauncherHandler& handler)
                 // Collect data for one second...
                 for (; timespan < 1000000000; ++count)
                 {
-                    // Add new metrics operation
-                    context._metrics->AddOperations(1);
-
                     timestamp = System::Timestamp();
 
                     // Run benchmark method...


### PR DESCRIPTION
I find the average time result obviously incorrect when latency setting is disabled. e.g. I changed the sleep example a little bit

```
#include "benchmark/cppbenchmark.h"

#include <chrono>
#include <thread>

const auto settings = CppBenchmark::Settings();

BENCHMARK("sleep", settings)
{
    std::this_thread::sleep_for(std::chrono::milliseconds(10));
}

BENCHMARK_MAIN()
```

For this simple example, I expect average/min/max time to be approximately 10ms, but the result is 
![image](https://user-images.githubusercontent.com/8855474/202157419-c409b1c1-ea60-4ae8-9d8b-2a41b928e5aa.png)
The average time is obviously incorrect. So I dug a little into the code and found that the test-drive used to calculate number of operations is excluded from metrics collection, whilst the operation is counted. Either the operation should be excluded (remove  the `AddOperations` call) or the metrics should be collected. I chose the latter approach. 
![image](https://user-images.githubusercontent.com/8855474/202160083-70015660-7737-4945-b36a-034f2cdd5f0f.png)

I guess the same problem exists for benchmark_thread and benchmark_pc but I haven't got the time to check it.
